### PR TITLE
Lock index sync

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -43,15 +43,9 @@ def set_up_indexing_timers(app):
                 sync_lock.acquire()
                 try:
                     with app.app_context():
-                        print('*'*80)
-                        print(f'Thread {os.getpid()} (locked) calling update_index')
-                        print('*'*80)
 
                         update_index(check_timeouts=False)
                 finally:
-                   print('*'*80)
-                   print(f'Process {os.getpid()} releasing lock')
-                   print('*'*80)
                    sync_lock.release()
 
         app.index_watchdog = multiprocessing.Process(target=index_watchdog, args=(app,))

--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 LOCKED = CHECKED = '1'
 UNLOCKED = '0'
 
+sync_lock = multiprocessing.Lock()
 
 def set_up_indexing_timers(app):
     if not app.config['INDEXING_ENABLED']:
@@ -39,9 +40,19 @@ def set_up_indexing_timers(app):
         def index_sync_loop(app):
             current_app.db.engine.dispose()
             while True:
-                with app.app_context():
-                    update_index(check_timeouts=False)
-                time.sleep(app.config['INDEXING_INTERVAL'])
+                sync_lock.acquire()
+                try:
+                    with app.app_context():
+                        print('*'*80)
+                        print(f'Thread {os.getpid()} (locked) calling update_index')
+                        print('*'*80)
+
+                        update_index(check_timeouts=False)
+                finally:
+                   print('*'*80)
+                   print(f'Process {os.getpid()} releasing lock')
+                   print('*'*80)
+                   sync_lock.release()
 
         app.index_watchdog = multiprocessing.Process(target=index_watchdog, args=(app,))
         app.index_watchdog.start()

--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -17,6 +17,7 @@ UNLOCKED = '0'
 
 sync_lock = multiprocessing.Lock()
 
+
 def set_up_indexing_timers(app):
     if not app.config['INDEXING_ENABLED']:
         return False
@@ -43,10 +44,9 @@ def set_up_indexing_timers(app):
                 sync_lock.acquire()
                 try:
                     with app.app_context():
-
                         update_index(check_timeouts=False)
                 finally:
-                   sync_lock.release()
+                    sync_lock.release()
 
         app.index_watchdog = multiprocessing.Process(target=index_watchdog, args=(app,))
         app.index_watchdog.start()


### PR DESCRIPTION
What?
=====

Prevent multiple gunicorn workers from fighting over the git lock

Why?
=====

This will reduce red herring error messages when debugging Knowledge Repo using the logs
