### PR TITLE
fix: decode the post.uuid before comparing it with other uuids

### DIFF
--- a/knowledge_repo/app/index.py
+++ b/knowledge_repo/app/index.py
@@ -153,9 +153,15 @@ def update_index(check_timeouts=True, force=False, reindex=False):
         posts = db_session.query(Post).all()
 
         for post in posts:
+            if isinstance(post.uuid, str) and post.uuid.starswith('\\x'):
+                decoded_post_uuid = bytes.fromhex(post.uuid.replace('\\x', ''))
+            elif isinstance(post.uuid, str):
+                decoded_post_uuid = bytes(post.uuid)
+            else:
+                decoded_post_uuid = post.uuid
 
             # If UUID has changed, check if we can find it elsewhere in the repository, and if so update index path
-            if post.uuid and ((post.path not in kr_dir) or (post.uuid != kr_dir[post.path].uuid)):
+            if post.uuid and ((post.path not in kr_dir) or (decoded_post_uuid != kr_dir[post.path].uuid)):
                 if post.uuid in kr_uuids:
                     logger.info('Updating location of post: {} -> {}'.format(post.path, kr_uuids[post.uuid].path))
                     post.path = kr_uuids[post.uuid].path
@@ -172,7 +178,7 @@ def update_index(check_timeouts=True, force=False, reindex=False):
             kp = kr_dir.pop(post.path)
 
             # Update metadata of post if required
-            if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != post.uuid):
+            if reindex or (kp.revision > post.revision or not post.is_published or kp.uuid != decoded_post_uuid):
                 if kp.is_valid():
                     logger.info('Recording update to post at: {}'.format(kp.path))
                     post.update_metadata_from_kp(kp)


### PR DESCRIPTION
What?
======

Properly encode the `post.uuid` value before comparing during `update_index`

Why?
=====

This should prevent every post from seeing its uuid as something new on every update check.